### PR TITLE
use File::HomeDir

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1,10 +1,11 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
+use File::HomeDir;
 use 5.010;
 
 my $arg = shift // 'help';
-my $home = $ENV{HOME};
+my $home = File::HomeDir->my_home;
 my $prefix = "$home/.rakudobrew";
 
 my %impls = (


### PR DESCRIPTION
Not all systems set $ENV{HOME} (or at least my Win 7 doesn't). Use File::HomeDir to get the home directory in a cross-platform manner. The suggestion given in #10 would be fine, too, though this change keeps the home directory as the workspace.
