### PR TITLE
Promote 'all' option in Usage message

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -59,7 +59,7 @@ if ($arg eq 'switch') {
     say "Usage:";
     say "rakudobrew current";
     say "rakudobrew list";
-    say "rakudobrew build [jvm|parrot|moar|moar_jit]";
+    say "rakudobrew build [jvm|parrot|moar|moar_jit|all]";
     say "rakudobrew build-panda";
     say "rakudobrew rehash";
     say "rakudobrew switch [jvm|parrot|moar|moar_jit]";


### PR DESCRIPTION
FWIW: 'all' does not install moar_jit which is probably what _most_ people expect, but is also technically wrong
