### PR TITLE
s/ moar_jit / moar_nojit /

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -17,8 +17,8 @@ my %impls = (
     moar => {
         configure => 'perl Configure.pl --backends=moar --gen-moar',
     },
-    moar_jit => {
-        configure => 'perl Configure.pl --backends=moar --gen-moar=master --moar-option=--enable-jit --gen-nqp=master',
+    moar_nojit => {
+        configure => 'perl Configure.pl --backends=moar --gen-moar=master --moar-option=--no-jit --gen-nqp=master',
     },
 );
 
@@ -59,10 +59,10 @@ if ($arg eq 'switch') {
     say "Usage:";
     say "rakudobrew current";
     say "rakudobrew list";
-    say "rakudobrew build [jvm|parrot|moar|moar_jit]";
+    say "rakudobrew build [jvm|parrot|moar|moar_nojit]";
     say "rakudobrew build-panda";
     say "rakudobrew rehash";
-    say "rakudobrew switch [jvm|parrot|moar|moar_jit]";
+    say "rakudobrew switch [jvm|parrot|moar|moar_nojit]";
 }
 
 sub current {
@@ -266,7 +266,7 @@ sub rehash {
         push @paths, "$prefix/$current/install/languages/perl6/site/bin";
     } elsif ($type eq 'moar') {
         push @paths, "$prefix/$current/install/languages/perl6/site/bin";
-    } elsif ($type eq 'moar_jit') {
+    } elsif ($type eq 'moar_nojit') {
         push @paths, "$prefix/$current/install/languages/perl6/site/bin";
     }
 


### PR DESCRIPTION
moar now defaults to jit, so use --backends=moar for jit and --backends=moar-nojit for without jit

https://github.com/coke/perl6-roast-data/blob/135314ee4e46a110d512959e7a3d4eb54bf5a8f7/bin/rakudo.moar.sh#L12
