### PR TITLE
Make git handling more robust (Closes #21)

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -3,6 +3,7 @@ use strict;
 use warnings;
 use 5.010;
 use FindBin qw($Bin);
+use Carp qw(croak);
 
 my $arg = shift // 'help';
 my $prefix = "$Bin/..";
@@ -29,7 +30,7 @@ my %impls = (
 );
 
 sub run {
-    system(@_) and die "Failed running ".$_[0]
+    system(@_) and croak "Failed running ".$_[0]
 }
 
 if ($arg eq 'switch') {

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -149,14 +149,21 @@ sub build_impl {
         say "Building $impl is NYI. Well volunteered!";
         return;
     }
-    $ver //= 'HEAD';
+    $ver //= 'nom';
     chdir $prefix;
     unless (-d "$impl-$ver") {
         run "$GIT clone $RAKUDO_REPO_URL $impl-$ver";
     }
     chdir "$impl-$ver";
-    run "$GIT pull";
-    run "$GIT checkout $ver";
+    run "$GIT fetch";
+    # of people say 'build somebranch', they usually mean 'build origin/somebranch'
+    my $ver_to_checkout = $ver;
+    eval {
+        run "$GIT rev-parse -q --verify origin/$ver";
+        $ver_to_checkout = "origin/$ver";
+    };
+    run "$GIT checkout $ver_to_checkout";
+
     if (-e 'Makefile') {
         run 'make realclean';
     }

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -147,7 +147,7 @@ sub build_impl {
         return;
     }
     unless (exists $impls{$impl}) {
-        say "Building $impl is NYI. Well volunteered!";
+        say "Building Rakudo with backend '$impl' is NYI. Well volunteered!";
         return;
     }
     $ver //= 'nom';

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -166,7 +166,9 @@ sub build_impl {
     run "$GIT checkout $ver_to_checkout";
 
     if (-e 'Makefile') {
-        run 'make realclean';
+        eval {
+            run 'make realclean';
+        };
     }
     run $impls{$impl}{configure};
     if (system 'make install') {


### PR DESCRIPTION
Use "git fetch" + "git checkout" instead of "git pull", because "pull" fails on detached HEADs.

Also includes a bit of unrelated robustness improvements.