### PR TITLE
Ambiguity and interpolation fixes

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -126,7 +126,7 @@ sub switch {
         return;
     }
     opendir(my $dh, $prefix);
-    my @match = grep { /$impl/ } list();
+    my @match = grep { /\Q$impl/ } list();
     my ($matched, $ambiguous) = @match;
     if ($ambiguous) {
         my ($exact) = grep { $_ eq $impl } @match;
@@ -344,7 +344,7 @@ sub test {
     if (!$impl) {
         $impl = current();
     }
-    my @match = grep { /$impl/ } list();
+    my @match = grep { /\Q$impl/ } list();
     my ($matched, $ambiguous) = @match;
     if ($ambiguous) {
         my ($exact) = grep { $_ eq $impl } @match;

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -128,6 +128,12 @@ sub switch {
     opendir(my $dh, $prefix);
     my @match = grep { /$impl/ } list();
     my ($matched, $ambiguous) = @match;
+    if ($ambiguous) {
+        my ($exact) = grep { $_ eq $impl } @match;
+        if ($exact) {
+            ($matched, $ambiguous) = $exact;
+        }
+    }
     if ($matched and not $ambiguous) {
         say "Switching to $matched";
         spurt("$prefix/CURRENT", $matched);
@@ -340,6 +346,12 @@ sub test {
     }
     my @match = grep { /$impl/ } list();
     my ($matched, $ambiguous) = @match;
+    if ($ambiguous) {
+        my ($exact) = grep { $_ eq $impl } @match;
+        if ($exact) {
+            ($matched, $ambiguous) = $exact;
+        }
+    }
     if ($matched and not $ambiguous) {
         say "Spectesting $matched";
         chdir "$prefix/$matched";


### PR DESCRIPTION
Mainly fixes an issue where you can never select an implementation which is named as a substring of another.  E.g. "rakudobrew switch moar-2014.12" was giving an ambiguity error between moar-2014.12 and moar-2014.12.1 if both were built.