### PR TITLE
use the expected perl5 interpreter

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -24,24 +24,25 @@ my %git_repos = (
 
 my $GIT = $ENV{GIT_BINARY} // 'git';
 my $RAKUDO_REPO_URL = 'https://github.com/rakudo/rakudo.git'; #Avoids problems with non-users
+my $PERL5 = $^X;
 
 my %impls = (
     parrot => {
         name      => "parrot",
         weight    => 10,
-        configure => "perl Configure.pl --backends=parrot --gen-parrot --gen-nqp --git-reference=$git_reference",
+        configure => "$PERL5 Configure.pl --backends=parrot --gen-parrot --gen-nqp --git-reference=$git_reference",
         need_repo => ['rakudo', 'nqp', 'parrot'],
     },
     jvm => {
         name      => "jvm",
         weight    => 20,
-        configure => "perl Configure.pl --backends=jvm --gen-nqp --git-reference=$git_reference",
+        configure => "$PERL5 Configure.pl --backends=jvm --gen-nqp --git-reference=$git_reference",
         need_repo => ['rakudo', 'nqp'],
     },
     moar => {
         name      => "moar",
         weight    => 30,
-        configure => "perl Configure.pl --backends=moar --gen-moar --git-reference=$git_reference",
+        configure => "$PERL5 Configure.pl --backends=moar --gen-moar --git-reference=$git_reference",
         need_repo => ['rakudo', 'nqp', 'MoarVM'],
     },
 );
@@ -284,15 +285,15 @@ sub build_triple {
     chdir "MoarVM";
     run "$GIT pull";
     run "$GIT checkout $moar_ver";
-    run "perl Configure.pl --prefix=../../install";
+    run "$PERL5 Configure.pl --prefix=../../install";
     run "make install";
 
     chdir "..";
-    run "perl Configure.pl --backend=moar --prefix=../install";
-    run "make install";
+    run "$PERL5 Configure.pl --backend=moar --prefix=../install";
+    run "$PERL5 install";
 
     chdir "..";
-    run "perl Configure.pl --backend=moar";
+    run "$PERL5 Configure.pl --backend=moar";
 
     if (system 'make install') {
         if ($^O eq "darwin") {


### PR DESCRIPTION
This would have rakudobrew use the same interpreter it was invoked with (and not whatever is aliased to the command `perl`, which may not be the perl someone uses to run rakudobrew)