### PR TITLE
work with the recent changes to install path

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -369,7 +369,7 @@ sub rehash {
     my $current = current() or return;
     my ($type) = split '-', $current;
 
-    my @paths = "$prefix/$current/install/bin";
+    my @paths = ("$prefix/$current/install/bin", "$prefix/$current/install/share/perl6/site/bin");
     if ($type eq 'parrot') {
         my $parverdir = `$prefix/$current/install/bin/parrot_config versiondir`;
         chomp $parverdir;


### PR DESCRIPTION
Without this, rakudobrew will not add a panda.bat to the rakudobrew/bin directory.