### PR TITLE
Correct nqp installation step in build_triple

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -295,7 +295,7 @@ sub build_triple {
 
     chdir "..";
     run "$PERL5 Configure.pl --backend=moar --prefix=../install";
-    run "$PERL5 install";
+    run "make install";
 
     chdir "..";
     run "$PERL5 Configure.pl --backend=moar";


### PR DESCRIPTION
In order to install nqp, the command 'perl install' was being used instead
of 'make install'.  This change corrects this issue and now
'rakudobrew triple YYYY.MM YYYY.MM YYYY.MM' works as expected.