### PR TITLE
Allow build-panda to accept a version number

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -93,7 +93,8 @@ if ($arg eq 'switch') {
     my ($rakudo_ver, $nqp_ver, $moar_ver) = (shift, shift, shift);
     build_triple($rakudo_ver, $nqp_ver, $moar_ver);
 } elsif ($arg eq 'build-panda') {
-    build_panda();
+    my $panda_ver = shift;
+    build_panda($panda_ver);
     rehash();
 } elsif ($arg eq 'self-upgrade') {
     self_upgrade();
@@ -112,7 +113,7 @@ if ($arg eq 'switch') {
     say "rakudobrew list";
     say "rakudobrew list-available";
     say "rakudobrew build " , (join "|", available_backends(), "all"), " [tag|branch|sha-1]", " [--configure-opts=]";
-    say "rakudobrew build-panda";
+    say "rakudobrew build-panda [panda-ver]";
     say "rakudobrew triple [rakudo-ver [nqp-ver [moar-ver]]]";
     say "rakudobrew rehash";
     say "rakudobrew switch ", (join "|", available_backends());
@@ -317,6 +318,8 @@ sub build_triple {
 }
 
 sub build_panda {
+    my ($panda_ver) = @_;
+    $panda_ver //= 'HEAD';
     my $impl = current();
     chdir "$prefix/$impl";
     unless (-d 'panda') {
@@ -324,6 +327,7 @@ sub build_panda {
     }
     chdir 'panda';
     run "$GIT pull";
+    run "$GIT checkout $panda_ver";
     run "perl6 rebootstrap.pl";
     say "Done, built panda for $impl";
 }


### PR DESCRIPTION
This change makes it possible for a given panda version to be installed
alongside a given moar/nqp/rakudo stack.  For instance, if one wants to
install Rakudo version 2015.04, then it is necessary to use the 2015.04
version of panda (the version is really the tag) since a newer version of
panda would use the Empty keyword which wasn't available in Rakudo 2015.04.
This change makes it possible to debug Perl6 modules across different
versions of Rakudo while also installing the module's dependencies via
panda.