### PR TITLE
use exec

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -370,7 +370,7 @@ sub rehash {
         if ($^O =~ /win32/i) {
             $contents = sprintf "\"%s\" %%*", $source;
         } else {
-            my $tmpl = "#!/bin/sh\nPATH=%s:\$PATH %s \"\$\@\"";
+            my $tmpl = "#!/bin/sh\nexport PATH=%s:\$PATH\nexec %s \"\$\@\"";
             $contents = sprintf $tmpl, $dirname, $basename;
         }
 


### PR DESCRIPTION
Currently perl6, etc., runs as a child process of /bin/sh.
```
> perl6 -e sleep &
[1] 4845
> ps f
  PID TTY      STAT   TIME COMMAND
...
32249 pts/3    Ss     0:00 -zsh
 4845 pts/3    SN     0:00  \_ /bin/sh /home/skaji/env/rakudobrew/bin/perl6 -e sleep
 4848 pts/3    RN     0:29  |   \_ /home/skaji/env/rakudobrew/moar-nom/install/bin/moar --execname=/home/skaji/env/rakudobrew/bin/../moar-nom/install/bin/perl6 --libpath=/home/skaji/env/rakudobrew/moar-nom/install/share/nqp/lib --libpath=/home/skaji/env/rakudobrew/moar-nom/install/share/perl6/lib --libpath=/home/skaji/env/rakudobrew/moar-nom/install/share/perl6/runtime /home/skaji/env/rakudobrew/moar-nom/install/share/perl6/runtime/perl6.moarvm -e sleep
 4860 pts/3    R+     0:00  \_ ps f
...
```
This pull request changes perl6, etc., shim to
```sh
#!/bin/sh
export PATH=/home/skaji/env/rakudobrew/bin/../moar-nom/install/bin:$PATH
exec perl6 "$@"
```
so that it runs as its own.