### PR TITLE
Fix build-panda command to run bootstrap.pl instead

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -498,7 +498,7 @@ sub build_panda {
     chdir 'panda';
     run "$GIT pull -q";
     run "$GIT checkout -q $panda_ver";
-    run which('perl6', $version) . " rebootstrap.pl";
+    run which('perl6', $version) . " bootstrap.pl";
     # Might have new executables now -> rehash.
     rehash();
     say "Done, built panda for $version";


### PR DESCRIPTION
rebootstrap.pl was obsoluted.
so run bootstrap.pl instead.
```
$ rakudobrew build-panda
rebootstrap is obsolete. You can upgrade your rakudo while keeping all installed distributions including panda.
Please run bootstrap.pl instead.
Updating shims
Done, built panda for moar-nom
Updating shims
```