### PR TITLE
try to match panda's version to the current rakudo

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -347,7 +347,7 @@ sub build_impl {
         return;
     }
     if ($impl eq "panda") {
-        build_panda();
+        build_panda($ver, $ver);
         return;
     } elsif ($impl eq "zef") {
         build_zef();
@@ -486,7 +486,6 @@ sub build_triple {
 
 sub build_panda {
     my ($panda_ver, $version) = @_;
-    $panda_ver //= 'HEAD';
     $version //= get_version();
     if (!$version) {
         say STDERR "$brew_name: No version set.";
@@ -499,11 +498,29 @@ sub build_panda {
     chdir 'panda';
     run "$GIT checkout master";
     run "$GIT pull -q";
-    run "$GIT checkout -q $panda_ver";
+
+    if (defined $panda_ver) {
+        run "$GIT checkout -q $panda_ver";
+    }
+    else {
+        # try to match panda's version to the current rakudo
+        $panda_ver = $version;
+        # moar-nom => nom, jvm-2016.01 => 2016.01, etc:
+        foreach my $backend_prefix (keys %impls) {
+            last if $panda_ver =~ s{$backend_prefix\-}{};
+        }
+        eval { run "$GIT checkout -q $panda_ver" };
+        if ($@) {
+            say "panda for $panda_ver not found";
+            say "Installing latest panda instead.";
+            $panda_ver = 'HEAD';
+            run "$GIT checkout -q $panda_ver";
+        }
+    }
     run which('perl6', $version) . " bootstrap.pl";
     # Might have new executables now -> rehash.
     rehash();
-    say "Done, built panda for $version";
+    say "Done, built panda $panda_ver for $version";
 }
 
 sub build_zef {


### PR DESCRIPTION
Hi! First of all let me thank you for rakudobrew: it's a great tool and the one thing I missed to start really digging into perl 6!

It [got my attention](https://github.com/travis-ci/travis-ci/issues/4910#issuecomment-147107862) that, when installing panda via `build-panda` or `build panda`, rakudobrew was not taking into account whether panda had a matching version for the rakudo it was built for. As a result, it was doing weird things like installing panda HEAD for a very old rakudo build (like pre v6.c).

This is a simple patch that attempts to fix this issue. It works the following way:

If the user has provided a version for panda (e.g. "`rakudobrew build-panda 2016.01`") then it honors said version and croaks if it can't find it.

However, if the user has NOT provided a version for panda (e.g. "`rakudobrew build-panda`") then it first tries to checkout a panda version that matches the current rakudo version being used. If it can't find a match, it fallbacks to panda's HEAD (with a mention on the logs). The user can still update its panda by simply doing a "rakudobrew build-panda HEAD".

I think this might help people trying to work with many different rakudo versions. It's specially interesting for Travis-CI, where you can now write on the `install` section:

    rakudobrew build-panda

instead of:

    rakudobrew build-panda $([ "$TRAVIS_PERL6_VERSION" == "latest" ] && echo "" || echo $TRAVIS_PERL6_VERSION)

Hope this is helpful! And thanks again for all the great work in rakudobrew :)

Cheers!