### PR TITLE
Use different weights for all backends

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -54,7 +54,7 @@ my %impls = (
     },
     'pre-glr' => {
         name      => "pre-glr",
-        weight    => 30,
+        weight    => 15,
         configure => "git checkout pre-glr; git pull; $PERL5 Configure.pl --backends=moar --gen-moar --git-reference=$git_reference --make-install",
         need_repo => ['rakudo', 'nqp', 'MoarVM'],
     },


### PR DESCRIPTION
Demote pre-glr as a backend

If you have 2 with the same weight, they can be randomized over
multiple runs.

Fixes #88