### PR TITLE
allow git@...:// urls when using GIT_PROTOCOL=ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ to the git binary using a `GIT_BINARY` environment variable:
 $ GIT_BINARY="%USERPROFILE%\Local Settings\Application Data\GitHub\PORTAB~1\bin\git.exe" rakudobrew build all
 ```
 
+## Specifying a git protocol
+
+By default, rakudobrew will use the git protocol when it clones repositories.
+To override this setting, use the `GIT_PROTOCOL` environment variable.
+
+```
+$ GIT_PROTOCOL=ssh rakudobrew list-available
+# uses git@github.com:/rakudo/rakudo.git
+
+$ GIT_PROTOCOL=https rakudobrew list-available
+# uses https://github.com/rakudo/rakudo.git
+```
+
 ## Command-line switches
 
 Run `rakudobrew`

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -26,11 +26,11 @@ my $GIT_PROTO = $ENV{GIT_PROTOCOL} // 'git';
 my $PERL5     = $^X;
 
 my %git_repos = (
-    rakudo => "$GIT_PROTO://github.com/rakudo/rakudo.git",
-    MoarVM => "$GIT_PROTO://github.com/MoarVM/MoarVM.git",
-    nqp    => "$GIT_PROTO://github.com/perl6/nqp.git",
-    panda  => "$GIT_PROTO://github.com/tadzik/panda.git",
-    zef    => "$GIT_PROTO://github.com/ugexe/zef.git",
+    rakudo => get_git_url($GIT_PROTO, 'github.com', 'rakudo', 'rakudo'),
+    MoarVM => get_git_url($GIT_PROTO, 'github.com', 'MoarVM', 'MoarVM'),
+    nqp    => get_git_url($GIT_PROTO, 'github.com', 'perl6',  'nqp'),
+    panda  => get_git_url($GIT_PROTO, 'github.com', 'tadzik', 'panda'),
+    zef    => get_git_url($GIT_PROTO, 'github.com', 'ugexe',  'zef'),
 );
 
 my %impls = (
@@ -989,4 +989,13 @@ sub do_exec {
     # Run.
     exec { $target } ($target, @$args);
     die "Executing $target failed with: $!";
+}
+
+sub get_git_url {
+    my ($protocol, $host, $user, $project) = @_;
+    if ($protocol eq "ssh") {
+        return "git\@${host}:${user}/${project}.git";
+    } else {
+        return "${protocol}://${host}/${user}/${project}.git";
+    }
 }


### PR DESCRIPTION
Fixes #93 & #94 

This lets git & https protocols work as before, but allows for an "ssh" protocol as well. Also adds docs for the env var.