### PR TITLE
Adds some instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ which should then be available as `perl6`.
 $ rakudobrew build zef
 ```
 
+## Building the last monthly build
+
+Rakudo Perl produces new versions every month on the 20th (ish);
+version names include the year and month, like this: `2017.08` (for
+August 2017). Get available versions by
+
+```
+$ rakudobrew list-available
+```
+
+and build it with
+
+```
+$ rakudobrew build moar 2017.08
+```
+
+`2017.08` is actually a tag in the Rakudo Perl repo. You can use any
+tag there to build that particular version. 
+
 ## Making new scripts available
 
 After you have installed new modules and scripts with zef or panda, you can run

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -31,7 +31,7 @@ $prefix and installing again. See
 https://github.com/tadzik/rakudobrew
 
 for installation instructions. You will also need to change the rakudobrew
-entry in your shell startup file (~/.profile) a bit. Run `rakudobrew init`
+entry in your shell startup file (~/.profile, ~/.bashrc or ~/.zshrc) a bit. Run `rakudobrew init`
 again to see how.
 
 If you don't want to upgrade, but just continue using the old version,
@@ -523,7 +523,8 @@ EOT
 # Load $brew_name automatically by adding
 #   eval "\$($brew_exec init <$available_shell_hooks_text>)"
 # to your local profile file.
-# (often ~/.bash_profile, ~/.zsh_profile or ~/.profile)
+# (often ~/.bash_profile, ~/.zsh_profile, ~/.profile
+# .bashrc or .zshrc )
 # This can be easily done using:
 
 echo 'eval "\$($brew_exec init <$available_shell_hooks_text>)"' >> ~/.profile

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -84,12 +84,12 @@ if ($arg eq 'switch') {
     $cur_backend //= '';
     $cur_rakudo  //= '';
     say "Available Rakudo versions:";
-    map { say $cur_rakudo eq $_ ? "* $_" : "  $_" } available_rakudos();
+    map { say $cur_rakudo eq $_ ? "→ $_" : "  $_" } available_rakudos();
     say "";
     $cur_backend |= '';
     $cur_rakudo |= '';
     say "Available backends:";
-    map { say $cur_backend eq $_ ? "* $_" : "  $_" } available_backends();
+    map { say $cur_backend eq $_ ? "→ $_" : "  $_" } available_backends();
 } elsif ($arg eq 'current') {
     if (my $c = get_version()) {
         say "Currently running $c"
@@ -284,7 +284,7 @@ exit;
 sub available_rakudos {
     my @output = qx|$GIT ls-remote --tags $git_repos{rakudo}|;
     my @tags = grep( m{refs/tags/([^\^]+)\^\{\}}, @output );
-    return sort grep { /^[\dv]/ } map(m{tags/([^\^]+)\^}, @tags);
+    return reverse sort grep { /^[\dv]/ } map(m{tags/([^\^]+)\^}, @tags);
 }
 
 sub list {


### PR DESCRIPTION
I kept going back to rakudobrew for instructions since I wasn't able to remember correctly the syntax. This small synopsis might help new- (or old-)comers to remember how to build the last available, stable (ish) version. 
Also reverses the list of available versions, so that newer appear first. 