### PR TITLE
User shell configuration

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -659,6 +659,35 @@ sub get_bin_paths {
     );
 }
 
+# Provide the user shell name.
+#
+# It checks the $ENV{'SHELL'} variable
+# or defaults to Bourne shell. Returns
+# the simple name of the shell (e.g., 'zsh').
+sub user_shell_name {
+    # default to Bourne shell if none is found
+    my $shell = $ENV{'SHELL'} || '/bin/sh';
+    $shell = ( splitdir( $shell ) )[ -1 ];
+    $shell =~ s/[^a-z]+$//; # remove version numbers
+    return $shell;
+}
+
+# Provides the guessed configuration file
+# for the user's shell or undef if none is found.
+sub guess_user_shell_configuration_file {
+    my $shell = user_shell_name;
+    my %profiles = ( 'bash' => [ '.bash_profile', '.profile' ],
+                     'csh'  => [ '.cshrc' ],
+                     'sh'   => [ '.profile' ],
+                     'zsh'  => [ '.zshenv', '.profile' ]
+        );
+
+
+    for ( @{ $profiles{ $shell } } ){
+        return $_ if ( -f catfile( $ENV{'HOME'} ,$_ ) );
+    }
+}
+
 sub init {
     my $brew_exec = catfile($RealBin, $brew_name);
     if ($^O =~ /win32/i) {
@@ -819,7 +848,7 @@ sub set_global_version {
 sub get_version {
     my $version = get_shell_version();
     return $version if defined $version;
-    
+
     # Check for local version by looking for a `.perl6-version` file in the current and parent folders.
     $version = get_local_version();
     return $version if defined $version;
@@ -926,7 +955,7 @@ sub do_exec {
     my ($program, $args) = @_;
 
     my $target = which($program);
-    
+
     # Run.
     exec { $target } ($target, @$args);
     die "Executing $target failed with: $!";

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -688,6 +688,18 @@ sub guess_user_shell_configuration_file {
     }
 }
 
+# Provides the correct line for exporting a variable
+# in the user's shell.
+sub user_shell_export_variable {
+    my ( $var_name, $var_value ) = @_;
+    my $shell = user_shell_name;
+
+    return sprintf 'setenv %s %s:$%s', $var_name, $var_value, $var_name if ( $shell =~ /t?csh$/ );
+    return sprintf 'export %s=%s:$%s', $var_name, $var_value, $var_name;
+
+}
+
+
 sub init {
     my $brew_exec = catfile($RealBin, $brew_name);
     if ($^O =~ /win32/i) {
@@ -713,8 +725,9 @@ EOT
     }
     else {
         if (@_ and $_[0] eq '-') {
+            my $export_path = user_shell_export_variable( 'PATH', $RealBin );
             say <<EOT;
-export PATH="$RealBin:\${PATH}"
+$export_path
 $brew_name() {
   local command
   command="\$1"

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -679,7 +679,7 @@ sub guess_user_shell_configuration_file {
     my %profiles = ( 'bash' => [ '.bash_profile', '.profile' ],
                      'csh'  => [ '.cshrc' ],
                      'sh'   => [ '.profile' ],
-                     'zsh'  => [ '.zshenv', '.profile' ]
+                     'zsh'  => [ '.zshenv', '.zshrc', '.zlogin' ]
         );
 
 

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -731,15 +731,23 @@ $brew_name() {
 }
 EOT
         }
-        else {
+else {
+    my $shell     = user_shell_name;
+    my $profile   = guess_user_shell_configuration_file || 'profile';
+    my $shell_msg = '(often ~/.bash_profile or ~/.profile)';
+
+    if ( $shell && $profile ){
+        $shell_msg = sprintf 'You seem to run %s with configuration in ~/%s', $shell, $profile;
+    }
+
         say <<EOT;
 # Load $brew_name automatically by adding
 #   eval "\$($brew_exec init -)"
 # to your local profile file.
-# (often ~/.bash_profile or ~/.profile)
+# $shell_msg
 # This can be easily done using:
 
-echo 'eval "\$($brew_exec init -)"' >> ~/.profile
+echo 'eval "\$($brew_exec init -)"' >> ~/$profile
 
 EOT
         }

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -682,6 +682,14 @@ sub guess_user_shell_configuration_file {
                      'zsh'  => [ '.zshenv', '.zshrc', '.zlogin' ]
         );
 
+    # add zsh files in custom paths
+    # it should be true that if ZDOTDIR has been set the user
+    # wants to use the zsh, but another shell could be
+    # in place now
+    if ( exists $ENV{ 'ZDOTDIR' } ){
+	push @{ $profiles{ 'zsh'} }, 
+	    map { catfile( $ENV{ 'ZDOTDIR' }, $_ ) } @{ $profiles{ 'zsh' } };
+    }
 
     for ( @{ $profiles{ $shell } } ){
         return $_ if ( -f catfile( $ENV{'HOME'} ,$_ ) );


### PR DESCRIPTION
A couple of simple functions to guess user's shell and configuration file and, therefore, instruct her a little better on where to place variables and exports.
Should help fixing issue #115 

Please note that I added the csh as possible running shell, but we should maybe advice users' to not run such shell combined with rakudobrew or rewrite the shell function to launch the executable in way csh can understand.