### PR TITLE
Help commands

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1060,5 +1060,14 @@ Usage: rakudobrew test [jvm|moar|moar-blead|all]
 Performs a C<make test> on the current version or the specified version.
 
 
+=head1 COMMAND: exec
+
+Usage: rakudobrew exec <command> [command-args]
+
+Performs an C<exec> system calls and therefore never returns back to the program.
+IN other words, this means that C<command> replaces rakudobrew. See the exec
+perldoc documentation for more details.
+
+
 
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1080,5 +1080,20 @@ When called with no arguments it does prints how to setup your shell
 for working with rakudobrew. Wehn called with C<-> it provides the shell function
 that will invoke rakudobrew the right way.
 
+=head1 COMMAND: versions
+
+Usage: rakudobrew versions
+
+Provides a list of installed Perl 6 versions.
+The current selected Perl 6 environment is marked with a star on the beginning
+of the line.
+
+
+=head1 COMMAND: list
+
+Usage: rakudobrew list
+
+The C<list> command is an alias for C<versions>, see the help
+for the latter.
 
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -265,7 +265,6 @@ EOT
 	# the user wants help for a specific command
 	# e.g., rakudobrew help list
 	my $command = $ARGV[ 0 ];
-	say "$brew_name help [$command]";
 
 	require Pod::Usage;
 	my $help_text = "";

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -285,7 +285,6 @@ EOT
 	$help_text = "Cannot find documentation for [$command]!" if ($help_text =~ /\A\s*\Z/);
 	close $pod_fh;
 	say $help_text;
-	exit;
     }
     else { 
 	# here the user does not want any specific help

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1022,4 +1022,35 @@ Usage: rakudobrew current
 The C<current> command provides details about the currently running Perl 6 instance.
 
 
+=head1 COMMAND: build
+
+Usage: rakudobrew build jvm|moar|moar-blead|all [tag|branch|sha-1] [--configure-opts=]
+
+Usage: rakudobrew build zef
+
+The C<build> command downloads, compiles and installs the specified C<tag> or C<version>
+or C<sha-1> pointing to a specific revision 
+of Perl 6 over the required backend C<moar>, C<moar-blead>, C<jvm> or C<all> of them.
+Please note that this could take a while, be patient.
+
+In the case the C<zef> argument is passed as the only one to C<build>, then
+the "zef" module manager is compiled and installed.
+
+
+=head1 COMMAND: triple
+
+Usage: rakudobrew triple [rakudo-ver [nqp-ver [moar-ver]]]
+
+The C<triple> command builds an instance of C<rakudo>, C<nqp> and C<moar>.
+Versions to be built can be specified cascading, otherwise the last version available
+is built.
+
+
+=head1 COMMAND: self-upgrade
+
+Usage: rakudobrew self-upgrade
+
+Performs a C<pull> from the git repository of the project, allowing the installation of the latest
+_version of rakudobrew.
+
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -999,5 +999,13 @@ Usage: rakudobrew nuke <version>
 The C<nuke> command totally destroy the specified Perl 6 version from your repository
 of installed backends.
 
+=head1 COMMAND: list-available
+
+Usage: rakudobrew list-available
+
+The C<list-available> command shows the most recent list of available Perl 6 instances 
+and backends that can be compiled and installed on the local Perl repository.
+Installed Perls will be marked with an asterisk at the beginning of the line.
+
 
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1053,4 +1053,12 @@ Usage: rakudobrew self-upgrade
 Performs a C<pull> from the git repository of the project, allowing the installation of the latest
 _version of rakudobrew.
 
+=head1 COMMAND: test
+
+Usage: rakudobrew test [jvm|moar|moar-blead|all]
+
+Performs a C<make test> on the current version or the specified version.
+
+
+
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1069,5 +1069,16 @@ IN other words, this means that C<command> replaces rakudobrew. See the exec
 perldoc documentation for more details.
 
 
+=head1 COMMAND: init
+
+Usage: rakudobrew init [-]
+
+The C<init> command performs some checks on the environment and provides
+either instructions on how to setup rakudobrew to work properly or
+a shell function to "alias" the command rakudobrew.
+When called with no arguments it does prints how to setup your shell
+for working with rakudobrew. Wehn called with C<-> it provides the shell function
+that will invoke rakudobrew the right way.
+
 
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -257,26 +257,62 @@ EOT
         }
     }
 } else {
-    say "Usage:";
-    say "$brew_name current";
-    say "$brew_name list-available";
-    say "$brew_name build " , (join "|", available_backends(), "all"), " [tag|branch|sha-1]", " [--configure-opts=]";
-    say "$brew_name build zef";
-    say "$brew_name triple [rakudo-ver [nqp-ver [moar-ver]]]";
-    say "$brew_name rehash";
-    say "$brew_name switch ", (join "|", available_backends());
-    say "$brew_name nuke ", (join "|", available_backends());
-    say "$brew_name self-upgrade";
-    say "$brew_name test [", (join "|", available_backends(), "all"), "]";
-    say "$brew_name exec <command> [command-args]";
-    say "$brew_name init";
-    say "$brew_name shell [--unset|version]";
-    say "$brew_name local [version]";
-    say "$brew_name global [version]";
-    say "$brew_name version";
-    say "$brew_name versions # or $brew_name list";
-    say "$brew_name which <command>";
-    say "$brew_name whence [--path] <command>";
+    # here we come for the 'help' command or
+    # nothing the program has been capable to
+    # understand
+    
+    if ( @ARGV == 1 ){
+	# the user wants help for a specific command
+	# e.g., rakudobrew help list
+	my $command = $ARGV[ 0 ];
+	say "$brew_name help [$command]";
+
+	require Pod::Usage;
+	my $help_text = "";
+	open my $pod_fh, ">", \$help_text;
+
+	Pod::Usage::pod2usage(
+	    -exitval   => "NOEXIT",  # do not terminate this script!
+	    -verbose   => 99,        # 99 = indicate the sections
+	    -sections  => "COMMAND: " . lc( $command ), # e.g.: COMMAND: list
+	    -output    => $pod_fh,   # filehandle reference
+	    -noperldoc => 1          # do not call perldoc for the high verbosity level (99)
+            );
+
+	# some cleanup
+	$help_text =~ s/\A[^\n]+\n//s;
+	$help_text =~ s/^    //gm;
+
+	$help_text = "Cannot find documentation for [$command]!" if ($help_text =~ /\A\s*\Z/);
+	close $pod_fh;
+	say $help_text;
+	exit;
+    }
+    else { 
+	# here the user does not want any specific help
+	# or we cannot understand what he wants, print
+	# a generic usage message
+	say "Usage:";
+	say "$brew_name current";
+	say "$brew_name list-available";
+	say "$brew_name build " , (join "|", available_backends(), "all"), " [tag|branch|sha-1]", " [--configure-opts=]";
+	say "$brew_name build zef";
+	say "$brew_name triple [rakudo-ver [nqp-ver [moar-ver]]]";
+	say "$brew_name rehash";
+	say "$brew_name switch ", (join "|", available_backends());
+	say "$brew_name nuke ", (join "|", available_backends());
+	say "$brew_name self-upgrade";
+	say "$brew_name test [", (join "|", available_backends(), "all"), "]";
+	say "$brew_name exec <command> [command-args]";
+	say "$brew_name init";
+	say "$brew_name shell [--unset|version]";
+	say "$brew_name local [version]";
+	say "$brew_name global [version]";
+	say "$brew_name version";
+	say "$brew_name versions # or $brew_name list";
+	say "$brew_name which <command>";
+	say "$brew_name whence [--path] <command>";
+    }
 }
 
 exit;
@@ -940,3 +976,28 @@ sub get_git_url {
         return "${protocol}://${host}/${user}/${project}.git";
     }
 }
+
+
+__END__
+
+
+=head1 NAME
+
+rakudobrew - Perl 6 environment manager
+
+=head1 SYNOPSIS
+
+rakudobrew command syntax:
+
+    rakuydobrew <command> [options] [arguments]
+
+
+=head1 COMMAND: nuke
+
+Usage: rakudobrew nuke <version>
+
+The C<nuke> command totally destroy the specified Perl 6 version from your repository
+of installed backends.
+
+
+=cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -1007,5 +1007,19 @@ The C<list-available> command shows the most recent list of available Perl 6 ins
 and backends that can be compiled and installed on the local Perl repository.
 Installed Perls will be marked with an asterisk at the beginning of the line.
 
+=head1 COMMAND: switch
+
+Usage: rakudobrew switch <version>
+
+The C<switch> command activates the specified version of the Perl 6 executable.
+The version specified must be installed on the local repository.
+
+
+=head1 COMMAND: current
+
+Usage: rakudobrew current
+
+The C<current> command provides details about the currently running Perl 6 instance.
+
 
 =cut

--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -309,7 +309,7 @@ EOT
 	say "$brew_name local [version]";
 	say "$brew_name global [version]";
 	say "$brew_name version";
-	say "$brew_name versions # or $brew_name list";
+	say "$brew_name versions|list";
 	say "$brew_name which <command>";
 	say "$brew_name whence [--path] <command>";
     }


### PR DESCRIPTION
I implemented a first simple usage help command related to each subcommand.
This makes implicit need for Pod::Usage.
The idea is to document in specific pod sections each command and its attributes/arguments, so that the program can automatically display help for a single command.
For instance:
`rakudobrew help build`
that is going to show the pod documentation for the build command. In the case no help command is required or the command is not found, the ordinary help is printed as already it is today.
This allows to fix issue #91 