### PR TITLE
Adds instructions, closes #139

### DIFF
--- a/bin/rakudobrew
+++ b/bin/rakudobrew
@@ -523,7 +523,7 @@ EOT
 # Load $brew_name automatically by adding
 #   eval "\$($brew_exec init <$available_shell_hooks_text>)"
 # to your local profile file.
-# (often ~/.bash_profile, ~/.zsh_profile or ~/.profile)
+# (often ~/.bashrc, ~/.zshrc, ~/.bash_profile, ~/.zsh_profile or ~/.profile)
 # This can be easily done using:
 
 echo 'eval "\$($brew_exec init <$available_shell_hooks_text>)"' >> ~/.profile


### PR DESCRIPTION
This worked for me. Adding it to .profile or .zsh_profile simply did not, even starting from a login shell. 